### PR TITLE
Manual scrolling -  Test and clean up

### DIFF
--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -32,14 +32,14 @@ export default class DynamicRadar extends Radar {
     this.skipList = null;
   }
 
-  scheduleUpdate(didUpdateItems) {
+  scheduleUpdate(didUpdateItems, promiseResolve) {
     // Cancel incremental render check, since we'll be remeasuring anyways
     if (this._nextIncrementalRender !== null) {
       this._nextIncrementalRender.cancel();
       this._nextIncrementalRender = null;
     }
 
-    super.scheduleUpdate(didUpdateItems);
+    super.scheduleUpdate(didUpdateItems, promiseResolve);
   }
 
   afterUpdate() {

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -213,7 +213,7 @@ const VerticalCollection = Component.extend({
     _radar._prevFirstVisibleIndex = _radar._prevFirstItemIndex = index;
     // Components will be rendered after schedule 'measure' inside 'update' method.
     // In our case, we need to focus the element after component is rendered. So passing the promise.
-    return new Promise ((resolve, reject) => {
+    return new Promise ((resolve) => {
       _radar.scheduleUpdate(false, resolve);
     });
   },

--- a/tests/helpers/test-scenarios.js
+++ b/tests/helpers/test-scenarios.js
@@ -95,6 +95,8 @@ export const standardTemplate = hbs`
 
       key=(either-or key "@identity")
 
+      registerAPI=(action (mut api))
+
       as |item i|}}
       <div
         class="vertical-item"

--- a/tests/integration/scroll-test.js
+++ b/tests/integration/scroll-test.js
@@ -480,6 +480,20 @@ testScenarios(
 );
 
 testScenarios(
+  'Can scroll to a specific index using the component public API',
+  dynamicSimpleScenarioFor(getNumbers(0, 50), { itemHeight: 100 }),
+  standardTemplate,
+
+  async function(assert) {
+    assert.expect(1);
+
+    await this.get('api').scrollToItem(10);
+
+    assert.equal(find('.vertical-item:first-of-type').textContent.trim(), '10 10', 'the 10th item in the list should be rendered first');
+  }
+);
+
+testScenarios(
   'The collection does not allow interaction before being setup',
   standardScenariosFor(getNumbers(100, 100)),
   standardTemplate,


### PR DESCRIPTION
Hi making some changes to see if we can get this merged into the base repo as the inclusion of this Public API would be a great tool to have.

Changes:
- Fixed the one linting issue breaking tests.
- Added a basic test to use the public API to scroll to an item at a specific index.
  - This required adding `registerAPI` as a prop in the `standardTemplate` in `test-scenarios.js`
- Fixed an issue where the promise from scroll to an index was not being passed along in `dynamic-radar.js`.

There was an additional test breaking, but that seems unrelated to this fork and is currently failing in `master` of `vertical-collection`.